### PR TITLE
Chenge customer model

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,2 +1,6 @@
 class Customer < ApplicationRecord
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
+  devise_for :users
   devise_for :customers
+  
   root to: "homes#top"
   get '/about' => "homes#about"
 
@@ -57,8 +59,6 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :order_details, only: [:update]
   end
-
-  devise_for :users
 
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,17 +4,7 @@ Rails.application.routes.draw do
   
   root to: "homes#top"
   get '/about' => "homes#about"
-
-  get '/customers/sign_up' => 'registrations#new'
-  post '/customers' => 'registrations#create'
-
-  get '/customers/sign_in' => 'sessions#new'
-  post '/customers/sign_in' => 'sessions#create'
-  delete '/customers/sign_out' => 'sessions#destroy'
-
   get '/customers/mypage' => 'customers#show'
-  get '/customers/edit' => 'customers#edit'
-  patch '/customers' => 'customers#update'
   get 'customers/check'
   patch 'customers/withdraw'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  devise_for :customers
   root to: "homes#top"
   get '/about' => "homes#about"
 

--- a/db/migrate/20230922054204_add_devise_to_customers.rb
+++ b/db/migrate/20230922054204_add_devise_to_customers.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class AddDeviseToCustomers < ActiveRecord::Migration[6.1]
+  def self.up
+    change_table :customers do |t|
+      ## Database authenticatable
+      #t.string :email,              null: false, default: ""
+      #t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      # t.integer  :sign_in_count, default: 0, null: false
+      # t.datetime :current_sign_in_at
+      # t.datetime :last_sign_in_at
+      # t.string   :current_sign_in_ip
+      # t.string   :last_sign_in_ip
+
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+
+      # Uncomment below if timestamps were not included in your original model.
+      # t.timestamps null: false
+    end
+
+    add_index :customers, :email,                unique: true
+    add_index :customers, :reset_password_token, unique: true
+    # add_index :customers, :confirmation_token,   unique: true
+    # add_index :customers, :unlock_token,         unique: true
+  end
+
+  def self.down
+    # By default, we don't want to make any assumption about how to roll back a migration when your
+    # model already existed. Please edit below which fields you would like to remove in this migration.
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_09_20_074011) do
+ActiveRecord::Schema.define(version: 2023_09_22_054204) do
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "addresses", force: :cascade do |t|
     t.string "address", null: false
@@ -46,6 +74,11 @@ ActiveRecord::Schema.define(version: 2023_09_20_074011) do
     t.string "post_code", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.index ["email"], name: "index_customers_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_customers_on_reset_password_token", unique: true
   end
 
   create_table "genres", force: :cascade do |t|
@@ -95,4 +128,6 @@ ActiveRecord::Schema.define(version: 2023_09_20_074011) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
[Update]customer_model→customerモデルにdevise機能を追加
[change]routes.rb:customer→routes.rbの中の記述の配置を変更
[Delete]routes.rb:customer→deviseで自動生成されたルーティングと自分たちで追加したルーティングが重複していたため、自分たちで追加したルーティングを削除
→URLに"/costomer/sign_up"を入れることでdeviseで自動生成されたサインアップページに飛べるようになってます。
※ブランチ名を"feature_new_customer_sign_up"にしたかったのですが、上手くできず、"Chenge customer model"になってます。